### PR TITLE
feat/add best_ & worst_offense methods and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage
+.DS_Store

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -62,4 +62,64 @@ class StatTracker
     end
     team_names.uniq.count
   end
+
+  def best_offense
+    goals_per_team = Hash.new()
+
+    @all_data_hash[:game_teams].each do |row|
+      if !goals_per_team[row[:team_id]]
+        goals_per_team[row[:team_id]] = []
+        goals_per_team[row[:team_id]] << row[:goals].to_i
+      else
+        goals_per_team[row[:team_id]] << row[:goals].to_i
+      end
+    end
+    goals_per_team
+
+    team_ids = goals_per_team.keys
+    goals_scored = goals_per_team.values
+
+    averages = []
+    goals_scored.each do |team_goals|
+      averages << team_goals.sum(0.0) / team_goals.length.round(2)
+    end
+    averages
+
+    team_averages = Hash[team_ids.zip(averages)]
+    highest_average = team_averages.max_by{|k, v| v}
+
+    @all_data_hash[:teams].find do |team|
+      team[:team_id].to_i == highest_average[0].to_i
+    end[:teamname]
+  end
+
+  def worst_offense
+    goals_per_team = Hash.new()
+
+    @all_data_hash[:game_teams].each do |row|
+      if !goals_per_team[row[:team_id]]
+        goals_per_team[row[:team_id]] = []
+        goals_per_team[row[:team_id]] << row[:goals].to_i
+      else
+        goals_per_team[row[:team_id]] << row[:goals].to_i
+      end
+    end
+    goals_per_team
+
+    team_ids = goals_per_team.keys
+    goals_scored = goals_per_team.values
+
+    averages = []
+    goals_scored.each do |team_goals|
+      averages << team_goals.sum(0.0) / team_goals.length.round(2)
+    end
+    averages
+
+    team_averages = Hash[team_ids.zip(averages)]
+    lowest_average = team_averages.min_by{|k, v| v}
+
+    @all_data_hash[:teams].find do |team|
+      team[:team_id].to_i == lowest_average[0].to_i
+    end[:teamname]
+  end
 end

--- a/spec/stat_tracker_dummy_spec.rb
+++ b/spec/stat_tracker_dummy_spec.rb
@@ -30,7 +30,7 @@ describe StatTracker do
   it '#average_goals_per_game' do
     expect(@stat_tracker.average_goals_per_game).to eq(3.85)
   end
-  
+
   it '#count_of_games_by_season' do
     expected = {
       "20122013" => 2,
@@ -43,6 +43,14 @@ describe StatTracker do
   end
 
   it '#count_of_teams' do
-    expect(@stat_tracker.count_of_teams). to eq (20)
+    expect(@stat_tracker.count_of_teams).to eq (20)
+  end
+
+  it '#best offense' do
+    expect(@stat_tracker.best_offense).to eq ("FC Dallas")
+  end
+
+  it '#worst offense' do
+    expect(@stat_tracker.worst_offense).to eq ("Sporting Kansas City")
   end
 end


### PR DESCRIPTION
Created the best_ and worst_offense methods that include: creating a hash with team_ids as keys and goals scored in each game as the value, finds the average number of goals scored per team per game, and identifies the team with the best and worst averages.